### PR TITLE
Fix compatibility with better-auth v1.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@daveyplate/better-auth-tauri",
     "homepage": "https://github.com/daveyplate/better-auth-tauri",
-    "version": "0.1.6",
+    "version": "0.1.7",
     "description": "Better Auth Tauri Plugin",
     "files": [
         "src",

--- a/src/plugin/callback-success.ts
+++ b/src/plugin/callback-success.ts
@@ -1,4 +1,4 @@
-import { createAuthEndpoint } from "better-auth/plugins"
+import { createAuthEndpoint } from "better-auth/api"
 import { html } from "./html"
 
 export const callbackSuccess = (successText: string) =>

--- a/src/plugin/tauri.ts
+++ b/src/plugin/tauri.ts
@@ -1,5 +1,5 @@
 import type { BetterAuthPlugin } from "better-auth"
-import { createAuthMiddleware } from "better-auth/plugins"
+import { createAuthMiddleware } from "better-auth/api"
 import { appendCallbackURL } from "./append-callback-url"
 import { callbackSuccess } from "./callback-success"
 import { checkCallbackURL } from "./check-callback-url"


### PR DESCRIPTION
The createAuthEndpoint is now exported from a different package so I fixed those. 
I tested it locally in my own app and it seems to work fine with v1.5 otherwise.